### PR TITLE
Fix exception at startup with node 10.x

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -69,7 +69,7 @@ function install() {
         return stdoutWrite.apply(this, arguments);
     };
 
-    if (process.stdin.end) {
+    if (typeof process.stdin.end === 'function') {
         process.stdin.end();
     }
     Object.defineProperty(process, 'stdin', {
@@ -102,7 +102,7 @@ export class Command {
         for (const [key, value] of context.env) {
             process.env[key] = value;
         }
-    
+
         // working directory
         finalizers.push((workingDirectory => () => process.chdir(workingDirectory))(process.cwd()));
         process.chdir(context.workingDirectory);


### PR DESCRIPTION
process.stdin.end is defined but not a function with 10.13 (it's set to
`Infinity due` to https://github.com/nodejs/node/blob/1e23e3ceb3217f2b0e076864fdbbe874a8603e2f/lib/internal/fs/streams.js#L90).

Make the call to it more guarded.