### PR TITLE
Fix node 10 and upgrade a few things

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -69,8 +69,8 @@ function install() {
         return stdoutWrite.apply(this, arguments);
     };
 
-    if (typeof process.stdin.end === 'function') {
-        process.stdin.end();
+    if (typeof process.stdin.destroy === 'function') {
+        process.stdin.destroy();
     }
     Object.defineProperty(process, 'stdin', {
         configurable: true,

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "dependencies": {
     "argparse": "^1.0.0",
     "@types/argparse": "^1.0.0",
-    "@types/node": "^8.0.0"
+    "@types/node": "^10.0.0"
   },
   "description": "Node.js server supporting the Nailgun protocol",
   "devDependencies": {
     "source-map-support": "^0.4.0",
-    "typescript": "^2.4.0"
+    "typescript": "^3.4.0"
   },
   "license": "Apache-2.0",
   "name": "@lucidsoftware/nodegun",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,10 @@
   version "1.0.30"
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.30.tgz#513c248995e5e695d1f665af462c77c4d1c179d6"
 
-"@types/node@^8.0.0":
-  version "8.0.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.22.tgz#9c6bfee1f45f5e9952ff6b487e657ecca48c7777"
+"@types/node@^10.0.0":
+  version "10.14.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.5.tgz#27733a949f5d9972d87109297cffb62207ace70f"
+  integrity sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==
 
 argparse@^1.0.0:
   version "1.0.9"
@@ -30,6 +31,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-typescript@^2.4.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@^3.4.0:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==


### PR DESCRIPTION
I was seeing errors like this when running Nodegun after upgrading to Node 10'

```
Error: shutdown ENOTCONN
    at Socket._final (net.js:361:25)
    at callFinal (_stream_writable.js:612:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

Changing `end()` to `destroy()` in this PR fixes it, but I'm not sure if this will have negative consequences.